### PR TITLE
Added account serializer

### DIFF
--- a/nflex_connector_utils/__init__.py
+++ b/nflex_connector_utils/__init__.py
@@ -10,6 +10,7 @@ from appliance import Appliance  # noqa
 from network import Network  # noqa
 from server import Server  # noqa
 from volume import Volume  # noqa
+from account import Account  # noqa
 from tools import serialize_list, vcr_cassette_context  # noqa
 
 from ._version import get_versions

--- a/nflex_connector_utils/account.py
+++ b/nflex_connector_utils/account.py
@@ -1,0 +1,39 @@
+import httplib
+
+
+class Account(object):
+    """
+        A representation of an Account
+    """
+
+    def __init__(self, id=None, metadata=None):
+        self.id = id
+        self.metadata = metadata
+
+    def serialize(self):
+        """Serialize the contents"""
+
+        results = {}
+        if self.id:
+            results["id"] = self.id
+
+        if self.metadata:
+            results["metadata"] = self.metadata.serialize()
+
+        return results
+
+    def update(self, api, account_id):
+        """Updates CMP(babel) account"""
+
+        if account_id is None:
+            '''For testing purposes, if the event doesn't have an account_id,
+               don't bother trying to POST to the accounts API.'''
+            return
+
+        response = api.patch(
+            path='/accounts/%s/resource' % account_id,
+            data=self.serialize())
+        if response.status_code != httplib.OK:
+            raise Exception(
+                'Got bad response from babel account API: %d, %s' % (
+                    response.status_code, response.content))

--- a/nflex_connector_utils/tests/test_account.py
+++ b/nflex_connector_utils/tests/test_account.py
@@ -1,0 +1,47 @@
+import pytest
+
+from nflex_connector_utils import Account, Metadata
+
+
+class TestAccount(object):
+    def test_account(self):
+        assert Account().serialize() == {}
+
+        assert Account(id='ACCOUNT_ID').serialize() == {
+            'id': 'ACCOUNT_ID'
+        }
+
+        metadata = Metadata([('regions', ['region1', 'region2'])])
+        assert Account(metadata=metadata).serialize() == {
+            'metadata': {
+                'provider_specific': {
+                    'regions': ['region1', 'region2'],
+                }
+            }
+        }
+
+        assert Account(id='ACCOUNT_ID', metadata=metadata).serialize() == {
+            'id': 'ACCOUNT_ID',
+            'metadata': {
+                'provider_specific': {
+                    'regions': ['region1', 'region2'],
+                }
+            }
+        }
+
+    def test_update(self, mocker):
+        account = Account()
+        assert account.update(api=None, account_id=None) is None
+
+        mocked_api = mocker.Mock()
+        mocked_api.patch.return_value = mocker.Mock()
+
+        mocked_api.patch.return_value.status_code = 200
+        mocked_api.patch.return_value.content = 'OK'
+        assert account.update(api=mocked_api, account_id='ACCOUNT_ID') is None
+
+        mocked_api.patch.return_value.status_code = 500
+        mocked_api.patch.return_value.content = 'NOT OK'
+        with pytest.raises(Exception):
+            assert account.update(api=mocked_api,
+                                  account_id='ACCOUNT_ID') is None

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     mock
     versioneer
     pytest-cov
+    pytest-mock
     flexer
     requests-mock
     flake8==2.5.1


### PR DESCRIPTION
this includes update method to update relevant cmp account with  new data.

I'm not convinced about update method, but im happy to discuss.
Maybe passing all parameters in constructor would be better?

This will work for both ECL2 and AWS. ECL2 doesn't pass id, maybe it is not needed by AWS as well?