### PR TITLE
Do not update account if there is no account id or it is not a production

### DIFF
--- a/nflex_connector_utils/account.py
+++ b/nflex_connector_utils/account.py
@@ -22,15 +22,15 @@ class Account(object):
 
         return results
 
-    def update(self, api, account_id):
+    def update(self, context, account_id):
         """Updates CMP account"""
 
-        if account_id is None:
+        if account_id is None or context.module_id is None:
             '''For testing purposes, if the event doesn't have an account_id,
                don't bother trying to POST to the accounts API.'''
             return
 
-        response = api.patch(
+        response = context.api.patch(
             path='/accounts/%s/resource' % account_id,
             data=self.serialize())
         if response.status_code != httplib.OK:

--- a/nflex_connector_utils/tests/test_account.py
+++ b/nflex_connector_utils/tests/test_account.py
@@ -31,17 +31,28 @@ class TestAccount(object):
 
     def test_update(self, mocker):
         account = Account()
-        assert account.update(api=None, account_id=None) is None
+        assert account.update(context=None, account_id=None) is None
+
+        mocked_context = mocker.Mock()
+        mocked_context.module_id = None
 
         mocked_api = mocker.Mock()
         mocked_api.patch.return_value = mocker.Mock()
 
         mocked_api.patch.return_value.status_code = 200
         mocked_api.patch.return_value.content = 'OK'
-        assert account.update(api=mocked_api, account_id='ACCOUNT_ID') is None
+
+        mocked_context.api = mocked_api
+        assert account.update(
+            context=mocked_context,
+            account_id='ACCOUNT_ID'
+        ) is None
 
         mocked_api.patch.return_value.status_code = 500
         mocked_api.patch.return_value.content = 'NOT OK'
+
+        mocked_context.module_id = 'e075735c-5ba2-4b8e-b497-45eb13940a42'
+        mocked_context.api = mocked_api
         with pytest.raises(Exception):
-            assert account.update(api=mocked_api,
+            assert account.update(context=mocked_context,
                                   account_id='ACCOUNT_ID') is None


### PR DESCRIPTION
Basically the connectors that can be scheduled per account have a new structure in the config.yaml that actually have an account id when testing through flexer so I need to add an extra check to see if the module is running on a production.

Here is the config.yaml structure present on per schedule connectors.

```json
name: provider
credentials_keys:
  - secret_access_key
  - access_key_id
account_id: some uui
resource:
  metadata:
    provider_specific:
      api_location: some location
  base:
    remote_id: some remote id
expected_metrics:
  - cpu-usage
expected_logs:
  - cpu-usage
expected_status:
  - 1
```